### PR TITLE
Libmnl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ ARG WIREGUARD_KERNEL_VERSION
 
 WORKDIR /tmp
 
-RUN dnf update -y && dnf install kmod koji -y && \
+RUN dnf update -y && dnf install kmod koji libmnl -y && \
         koji download-build --rpm --arch=x86_64 kernel-core-${WIREGUARD_KERNEL_VERSION} && \
         koji download-build --rpm --arch=x86_64 kernel-modules-${WIREGUARD_KERNEL_VERSION} && \
         dnf install /tmp/kernel-core-${WIREGUARD_KERNEL_VERSION}.rpm \

--- a/atomic-wireguard-module
+++ b/atomic-wireguard-module
@@ -24,6 +24,8 @@
 
 set -e
 
+source /etc/sysconfig/atomic-wireguard
+
 WIREGUARD_KERNEL_VERSION=$(uname -r)
 
 build_wireguard()


### PR DESCRIPTION
This fixes the error message when trying to run wg:
`/usr/bin/wg: error while loading shared libraries: libmnl.so.0: cannot open shared object file: No such file or directory`